### PR TITLE
fix.스킬 사용횟수 카운팅 시, 커스텀 스킬이 집계되지않는 문제 수정

### DIFF
--- a/src/claude_hub/services/log_parser.py
+++ b/src/claude_hub/services/log_parser.py
@@ -1,8 +1,12 @@
 """세션 로그 파서 — JSONL에서 스킬/플러그인 사용 이벤트 추출."""
 import json
+import re
 from pathlib import Path
-from claude_hub.services.usage_db import UsageDB
+from claude_hub.services.usage_db import UsageDB, BUILTIN_COMMANDS
 from claude_hub.utils.paths import ClaudePaths
+
+# harness가 slash command 실행 시 user message에 삽입하는 태그 패턴
+_COMMAND_NAME_RE = re.compile(r"<command-name>/?([^<]+)</command-name>")
 
 
 def parse_session_logs(paths: ClaudePaths, db: UsageDB) -> dict:
@@ -43,20 +47,32 @@ def _parse_single_file(path: Path, project: str, db: UsageDB) -> int:
 
 def _extract_skill_usage(entry: dict, project: str, db: UsageDB) -> int:
     """JSONL 엔트리에서 Skill/Agent 사용 이벤트를 추출하여 DB 기록. 기록된 이벤트 수 반환."""
-    # JSONL 구조: {"message": {"role": "assistant", "content": [...]}} 또는 {"role": "assistant", "content": [...]}
     msg = entry.get("message", entry)
-    if msg.get("role") != "assistant":
+    role = msg.get("role", "")
+    session_id = str(entry.get("session_id", entry.get("sessionId", "")))
+    count = 0
+
+    # user message: harness가 slash command 실행 시 삽입하는 <command-name> 태그 감지
+    if role == "user":
+        content = msg.get("content", [])
+        text = content if isinstance(content, str) else json.dumps(content, ensure_ascii=False)
+        for m in _COMMAND_NAME_RE.finditer(text):
+            skill_name = m.group(1).strip()
+            if skill_name and skill_name not in BUILTIN_COMMANDS:
+                db.record_event(type="skill", name=skill_name, project=project, session_id=session_id)
+                count += 1
+        return count
+
+    # assistant message: Skill/Agent tool_use 블록 감지
+    if role != "assistant":
         return 0
 
     content = msg.get("content", [])
     if not isinstance(content, list):
         return 0
 
-    count = 0
     for block in content:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") != "tool_use":
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
             continue
 
         tool_name = block.get("name", "")
@@ -65,23 +81,13 @@ def _extract_skill_usage(entry: dict, project: str, db: UsageDB) -> int:
         if tool_name == "Skill":
             skill_name = tool_input.get("skill", "") if isinstance(tool_input, dict) else ""
             if skill_name:
-                db.record_event(
-                    type="skill",
-                    name=skill_name,
-                    project=project,
-                    session_id=str(entry.get("session_id", "")),
-                )
+                db.record_event(type="skill", name=skill_name, project=project, session_id=session_id)
                 count += 1
 
         elif tool_name == "Agent":
             subagent = tool_input.get("subagent_type", "") if isinstance(tool_input, dict) else ""
             if subagent:
-                db.record_event(
-                    type="agent",
-                    name=subagent,
-                    project=project,
-                    session_id=str(entry.get("session_id", "")),
-                )
+                db.record_event(type="agent", name=subagent, project=project, session_id=session_id)
                 count += 1
 
     return count

--- a/src/claude_hub/services/usage_db.py
+++ b/src/claude_hub/services/usage_db.py
@@ -6,6 +6,15 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 
+# Claude Code 빌트인 CLI 명령어 — 스킬 집계에서 제외
+BUILTIN_COMMANDS = frozenset({
+    "help", "clear", "compact", "config", "cost", "doctor", "init",
+    "login", "logout", "memory", "model", "permissions", "review",
+    "status", "terminal-setup", "vim", "fast", "slow", "bug",
+    "listen", "mcp", "add-dir", "approved-tools", "context",
+    "resume", "plan", "plugin",
+})
+
 
 @dataclass
 class UsageDB:
@@ -68,13 +77,15 @@ class UsageDB:
 
     def get_top_skills(self, limit: int = 10, days: int = 30) -> list[dict]:
         cutoff = time.time() - (days * 86400)
+        placeholders = ",".join("?" * len(BUILTIN_COMMANDS))
         with self._connect() as conn:
             conn.row_factory = sqlite3.Row
             rows = conn.execute(
-                """SELECT name, COUNT(*) as hit_count, MAX(timestamp) as last_used
-                   FROM usage_events WHERE type = 'skill' AND timestamp >= ?
+                f"""SELECT name, COUNT(*) as hit_count, MAX(timestamp) as last_used
+                   FROM usage_events
+                   WHERE type = 'skill' AND timestamp >= ? AND name NOT IN ({placeholders})
                    GROUP BY name ORDER BY hit_count DESC LIMIT ?""",
-                (cutoff, limit),
+                (cutoff, *BUILTIN_COMMANDS, limit),
             ).fetchall()
             return [dict(r) for r in rows]
 


### PR DESCRIPTION
```markdown
  ## Feature or BugFix PR

  ### 1. 개요

  1) 사용자가 `/gen-pr` 같은 커스텀 스킬을 직접 실행하면 harness가 `<command-name>` 태그를 user message에 삽입하는
   방식으로 처리하는데, 기존 log_parser는 assistant의 Skill tool_use만 감지해서 이 경로가 전부 누락됨.
  AI가 자동 호출하는 스킬(superpowers 등)만 집계되고, 사용자가 `/`로 직접 실행하는 커스텀 스킬은 카운트
  안 되는 문제 수정. 
 2) 추가로 `/clear`, `/login` 같은 빌트인 CLI 명령어가 스킬로 잘못 집계되지 않도록 필터링 적용.

  ### 2. 관련 이슈

  - 스킬 사용횟수 카운팅 시, 커스텀 스킬이 집계되지않는 문제 수정

  ### 3. 변경 사항

  - log_parser의 `_extract_skill_usage`에서 user message의 `<command-name>` 태그도 감지하도록 확장함.
  content를 문자열화해서 정규식 한번으로 처리
  - 빌트인 CLI 명령어(`clear`, `login`, `status` 등 27개) 블랙리스트를 `usage_db.py`에
  `BUILTIN_COMMANDS`로 정의하고, 파싱 시점과 조회 시점(`get_top_skills` SQL) 양쪽에서 필터링 적용
  - log_parser 단위 테스트 신규 작성 (tool_use 감지, command-name 태그 감지, 빌트인 필터링 등 15개
  케이스)

  ### 4. 테스트 방법

  - 커스텀 스킬 사용 후 집계되는지 체크

  ### 5. 참고 자료

  없음
  ```